### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Fixes Missing Activity: GitHub Skills

This PR addresses Issue #6 by adding the missing GitHub Skills activity that was announced by the principal.

### ✅ **Changes Made:**
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- **Description**: Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.
- **Schedule**: Wednesdays, 3:30 PM - 5:00 PM  
- **Max Participants**: 25 students
- **Current Participants**: Empty (ready for student signups)

### ⏱️ **Why This is Urgent:**
- Students have been unable to find this activity to sign up
- Registration deadline is end of this week
- Part of GitHub Certifications program that helps with college applications
- Many students are eager to join as mentioned in the issue

### 🧪 **Testing:**
- Verified the activity structure is correct
- Confirmed the application loads without errors
- Total activities now: 10 (previously 9)

**Closes #6**

**Note**: This change allows students to immediately sign up for the GitHub Skills activity before the registration deadline.